### PR TITLE
Filter by start/end time on catalog map

### DIFF
--- a/ioos_catalog/models/dataset.py
+++ b/ioos_catalog/models/dataset.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from bson.objectid import ObjectId
+from datetime import datetime
 
 from ioos_catalog import db,app
 from ioos_catalog.models.base_document import BaseDocument
@@ -39,6 +40,8 @@ class Dataset(BaseDocument):
                 'keywords'          : [unicode],  # Search keywords
                 'variables'         : [unicode],  # Environmental properties measured by this dataset
                 'asset_type'        : unicode,    # See the IOOS vocablary for assets: http://mmisw.org/orr/#http://mmisw.org/ont/ioos/platform
+                'time_min': datetime, # start time of this service
+                'time_max': datetime, # end time of this service
                 'geojson'           : dict,       # GeoJSON of the datasets location (point / line / polygon) as a dict
                 'messages'          : [unicode],    # messages regarding the harvesting of this
                 'created'           : datetime,

--- a/ioos_catalog/models/migration/migrate_150427.py
+++ b/ioos_catalog/models/migration/migrate_150427.py
@@ -1,0 +1,12 @@
+from ioos_catalog import db, app
+
+def migrate():
+    """Adds min and max time to datasets"""
+    with app.app_context():
+        datasets = db.Dataset.find()
+        for d in datasets:
+            for i, s in enumerate(d['services']):
+                d['services'][i]['time_min'] = None
+                d['services'][i]['time_max'] = None
+            d.save()
+

--- a/ioos_catalog/tasks/harvest.py
+++ b/ioos_catalog/tasks/harvest.py
@@ -40,6 +40,10 @@ from ioos_catalog.tasks.debug import debug_wrapper, breakpoint
 #from ioos_catalog.models import MetricCount
 from functools import wraps
 from datetime import datetime
+# mainly for conversion from np.datetime64 -> datetime.datetime
+from pandas import Timestamp
+from dateutil.parser import parse
+from netCDF4 import num2date
 
 def queue_harvest_tasks():
     """
@@ -700,6 +704,69 @@ class DapHarvest(Harvester):
         url_res.close()
         return gj
 
+
+    @classmethod
+    def get_time_from_dim(cls, time_var):
+        """Get min/max from a NetCDF time variable and convert to datetime"""
+        ndim = len(time_var.shape)
+        if ndim == 0:
+            ret_val = time_var.item()
+            res = ret_val, ret_val
+        elif ndim == 1:
+            # NetCDF Users' Guide states that when time is a coordinate variable,
+            # it should be monotonically increasing or decreasing with no
+            # repeated variables. Therefore, first and last elements for a
+            # vector should correspond to start and end time or end and start
+            # time respectively. See Section 2.3.1 of the NUG
+            res = time_var[0], time_var[-1]
+        else:
+            # TODO: use more efficient algorithm for finding max here
+            try:
+                if hasattr(time_var, 'calendar'):
+                    times = num2date(var[:], var.units, var.calendar)
+                else:
+                    times = num2date(var[:], var.units)
+                return np.min(times), np.max(times)
+            # need to add test
+            except ValueError:
+                return None, None
+
+        # if not > 1d, return the min and max elements found
+        min_elem, max_elem = np.min(res), np.max(res)
+        if hasattr(time_var, 'calendar'):
+            num2date([min_elem, max_elem], time_var.units,
+                      time_var.calendar)
+            return num2date([min_elem, max_elem], time_var.units,
+                            time_var.calendar)
+        else:
+            return num2date([min_elem, max_elem], time_var.units)
+
+
+
+    def get_min_max_time(self, cd):
+        """
+           Attempt to naively find a time variable in the dataset
+           and get the min/max
+        """
+        for v in cd._current_variables:
+            # we need a udunits time string in order for this to work
+            var = cd.nc.variables[v]
+            if hasattr(var, 'units'):
+                # assume this is time if 'since' is in the units string
+                # or this is the 'T' axis
+                if ('since' in var.units.lower() or
+                    (hasattr(var, 'axis') and var.axis == 'T') or
+                    (hasattr(var, 'standard_name') and
+                     var.standard_name == 'time')):
+                    try:
+                        return DapHarvest.get_time_from_dim(var)
+                    except:
+                        return None, None
+        return None, None
+
+
+
+
     def harvest(self):
         """
         Identify the type of CF dataset this is:
@@ -717,7 +784,18 @@ class DapHarvest(Harvester):
                                                    type(e).__name__, e))
             return 'Not harvested'
 
-
+        # rely on times in the file first over global atts for calculating
+        # start/end times of dataset.
+        tmin, tmax = self.get_min_max_time(cd)
+        # if nothing was returned, try to get from global atts
+        if (tmin == None and tmax == None and
+            'time_coverage_start' in cd.metadata and
+            'time_coverage_end' in cd.metadata):
+            try:
+                tmin, tmax = (parse(cd.metadata[t]) for t in
+                                   ('time_coverage_start', 'time_coverage_end'))
+            except ValueError:
+                tmin, tmax = None, None
         # For DAP, the unique ID is the URL
         unique_id = self.service.get('url')
 
@@ -932,6 +1010,8 @@ class DapHarvest(Harvester):
             'data_provider':  self.service.get('data_provider'),
             'metadata_type':  u'ncml',
             'metadata_value': unicode(dataset2ncml(cd.nc, url=self.service.get('url'))),
+            'time_min': tmin,
+            'time_max': tmax,
             'messages':       map(unicode, messages),
             'keywords':       keywords,
             'variables':      map(unicode, final_var_names),

--- a/ioos_catalog/tasks/harvest.py
+++ b/ioos_catalog/tasks/harvest.py
@@ -732,16 +732,10 @@ class DapHarvest(Harvester):
             # time respectively. See Section 2.3.1 of the NUG
             res = time_var[0], time_var[-1]
         else:
-            # TODO: use more efficient algorithm for finding max here
-            try:
-                if hasattr(time_var, 'calendar'):
-                    times = num2date(var[:], var.units, var.calendar)
-                else:
-                    times = num2date(var[:], var.units)
-                return np.min(times), np.max(times)
-            # need to add test
-            except ValueError:
-                return None, None
+            # FIXME: handle multidimensional time variables.  Perhaps
+            # take the first and last element of time variable in the first
+            # dimension and then take the min and max of the resulting values
+            return None, None
 
         # if not > 1d, return the min and max elements found
         min_elem, max_elem = np.min(res), np.max(res)

--- a/ioos_catalog/templates/catalog_map.html
+++ b/ioos_catalog/templates/catalog_map.html
@@ -9,6 +9,9 @@
 <!--TODO: change to non-cdn assets later.  Use bower? -->
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.css" />
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.Default.css" />
+<link rel="stylesheet" href="{{ url_for('.static', filename='css/jquery.datetimepicker.css') }}"
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.7.14/css/bootstrap-datetimepicker.min.css">
+
 {% endblock %}
 
 {% block basepage %}
@@ -99,7 +102,50 @@
       <label for="variable-filter">
           Filter by variable text (separate multiple terms with commas)
       </label>
+
       <input type="text" name="variable-filter">
+      <div class="container">
+        <div class='row'>
+          <div class='col-md-3'>
+            <div class="form-group">
+              <label for='start-time'>Start Time</label>
+              <div class='input-group date' id='start-time'>
+                <input type='text' name='start-time' class="form-control" />
+                <span class="input-group-addon">
+                  <span class="glyphicon glyphicon-calendar"></span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class='row'>
+          <div class='col-md-3'>
+            <div class="form-group">
+              <label for='end-time'>End Time</label>
+              <div class='input-group date' id='end-time'>
+                <input type='text' name='end-time' class="form-control" />
+                <span class="input-group-addon">
+                  <span class="glyphicon glyphicon-calendar"></span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class='row'>
+          <div class='col-md-3'>
+            <button type="submit" id='map-search' class="btn btn-default">Search</button>
+          </div>
+        </div>
+      </div>
+      <!--
+      <label for="date_timepicker_start">Start date/time (UTC)</label>
+      <input type="text" name="date_timepicker_start"
+             id="date_timepicker_start">
+      <label for="date_timepicker_end">End date/time (UTC)</label>
+      <input type="text" name="date_timepicker_end"
+             id="date_timepicker_end">
+      -->
+
     </div>
 
     <h4 id="search_contents"></h4>
@@ -113,9 +159,12 @@
 
 <script type="text/javascript" src="{{ url_for('.static', filename='js/d3.v3.min.js') }}"></script>
 <script type="text/javascript" src="{{ url_for('.static', filename='js/queue.v1.min.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('.static', filename='js/jquery.datetimepicker.js') }}"></script>
 <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
 <script type="text/javascript" src="{{ url_for('.static', filename='js/leaflet.textpath.js') }}"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/leaflet.markercluster.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.2/moment.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.7.14/js/bootstrap-datetimepicker.min.js"></script>
 <script type="text/javascript">
 
 function toggleInfo(did, sindex) {
@@ -179,44 +228,48 @@ function setupFilters() {
       }
       // if the asset type filter is set, use it
       var assetVal = $('select[name="asset-type"]').val();
-      /* the asset value doesn't seem to be defaulting to "Any" (value '-')
-         despite the selected attribute */
       if (assetVal !== '-' && assetVal !== null) {
           qsArgs['asset_type'] = assetVal;
       }
-      var inputVal = $('input[name="variable-filter"]').val(); 
+      var inputVal = $('input[name="variable-filter"]').val();
       if (inputVal != '') {
         qsArgs['variable'] = inputVal
       }
-      // generate any query string params if present
-      if (!$.isEmptyObject(qsArgs)) {
-          url += '?' + $.param(qsArgs) 
-          console.log(url);
-      /* If the object was empty, there is a chance the site will be as well.
-         we don't want to select all datasets, so return instead if this is the
-         case */
-      } else if (url === baseUrl + 'null/') {
-             return
-      }
+
+      if (url === baseUrl + 'null/') {
+         return
+      } else {
+
+      var startDate = $("#start-time").data().date || null;
+      if (startDate !== null) qsArgs['start_date'] = startDate
+
+      var endDate = $("#end-time").data().date || null;
+      if (endDate !== null) qsArgs['end_date'] = endDate;
+
+      url += '?' + $.param(qsArgs)
+
       console.log("Loading...");
       /* Overlay a spinner to let the user know that
          the data is being loaded */
       addSpinner();
       d3.json(url, addData);
+    }
   }
 
-  $('select[name^="filter"]').change(function() {
-      build_filter_url();
+  var mapSearch = $("#map-search");
+  mapSearch.click(function () { build_filter_url() })
+  var mapFilt = $('select[name^="filter"]');
+  var disableGrp = $('[name="asset-type"], [name="variable-filter"], #start-time *, #end-time *, #map-search');
+  mapFilt.change(function() {
+     /* check if a provider is set.  If it is not,
+        disable the search button */
+    var filtVal = mapFilt.val()
+    if (filtVal === '-') {
+        disableGrp.prop('disabled', true);
+    } else {
+        disableGrp.prop('disabled', false);
+    }
   });
-
-  var varInput = $('input[name="variable-filter"]');
-  varInput.change(function () {
-      build_filter_url();
-  });
-
-  $('select[name="asset-type"]').change(function () {
-      build_filter_url();
-  })
 
 }
 
@@ -469,7 +522,7 @@ function addData(error, geojson) {
       map.removeLayer(hoverLayer);
   }
 
- 
+
   //zoom to currently selected dataset
   var datasetBounds = L.geoJson(geojson).getBounds();
   //guard against providers which currently no datasets,
@@ -494,11 +547,11 @@ function addData(error, geojson) {
 
   var filtPoint;
 
-  if (geojson.features.length > 0) { 
+  if (geojson.features.length > 0) {
      $('#search_contents').text("Search returned " + geojson.features.length +
                                 " results");
   } else {
-     $('#search_contents').text("Search returned no results"); 
+     $('#search_contents').text("Search returned no results");
   }
 
   for (var i = 0; i < geojson.features.length; ++i) {
@@ -613,7 +666,46 @@ $(function() {
       alert('Catalog map is presently incompatible with Internet Explorer.');
       window.location = '/';
   }
+
+  var d_opts = {format: "YYYY-MM-DDTHH:SSZ",
+                defaultDate: null}
+  $('#start-time').datetimepicker(d_opts);
+  $('#end-time').datetimepicker(d_opts);
+  $("#start-time").on("dp.change", function (e) {
+      try {
+        $('#end-time').data("DateTimePicker").minDate(e.date);
+      } catch (x) {
+        delete $('#end-time').data("DateTimePicker").minDate;
+      }
+  });
+  $("#end-time").on("dp.change", function (e) {
+      try {
+        $('#start-time').data("DateTimePicker").maxDate(e.date);
+      } catch (x) {
+        delete $('#start-time').data("DateTimePicker").maxDate;
+      }
+  });
+
   $('select').val(defaultVal, true).trigger('change');
+  //bind timepicker
+
+   jQuery('#date_timepicker_start').datetimepicker({
+  format:'Y-m-d H:i',
+  onShow:function( ct ){
+   this.setOptions({
+    maxDate:jQuery('#date_timepicker_end').val()?jQuery('#date_timepicker_end').val():false
+   })
+  },
+ });
+ jQuery('#date_timepicker_end').datetimepicker({
+  format:'Y-m-d H:i',
+  onShow:function( ct ){
+   this.setOptions({
+    minDate:jQuery('#date_timepicker_start').val()?jQuery('#date_timepicker_start').val():false
+
+   })
+  },
+ });
 });
 
 </script>

--- a/ioos_catalog/templates/catalog_map.html
+++ b/ioos_catalog/templates/catalog_map.html
@@ -9,7 +9,6 @@
 <!--TODO: change to non-cdn assets later.  Use bower? -->
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.css" />
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.Default.css" />
-<link rel="stylesheet" href="{{ url_for('.static', filename='css/jquery.datetimepicker.css') }}"
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.7.14/css/bootstrap-datetimepicker.min.css">
 
 {% endblock %}
@@ -159,7 +158,6 @@
 
 <script type="text/javascript" src="{{ url_for('.static', filename='js/d3.v3.min.js') }}"></script>
 <script type="text/javascript" src="{{ url_for('.static', filename='js/queue.v1.min.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('.static', filename='js/jquery.datetimepicker.js') }}"></script>
 <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
 <script type="text/javascript" src="{{ url_for('.static', filename='js/leaflet.textpath.js') }}"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/leaflet.markercluster.js"></script>

--- a/ioos_catalog/views/catalog_map.py
+++ b/ioos_catalog/views/catalog_map.py
@@ -73,7 +73,7 @@ def geoj(filter_provider):
             feat = {'type':'Feature',
                     'properties':{'id':str(d._id),
                                   'sindex': idx,        # service index
-                                  'name':s['name'],
+                                  'name': s['name'],
                                   'service_name': service_name,
                                   'description':s['description']},
                     'geometry': s.get('geojson')}

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,3 @@ git+https://github.com/ioos/petulant-bear.git
 git+https://github.com/ioos/compliance-checker.git
 Flask-Captcha==0.1.8
 six==1.9.0
-arrow==0.4.3


### PR DESCRIPTION
Adds start and end time to Mongo documents for datasets. (migration included)
Attempts to get start and end time of DAP and SOS datasets on harvest.
Adds time handling in asset map views.
Adds time filtering capabilities to catalog map interface along with other minor alterations.

Implements #384