### PR TITLE
Fixes CSW harvesting bug for ERDDAP URLs

### DIFF
--- a/ioos_catalog/tasks/reindex_services.py
+++ b/ioos_catalog/tasks/reindex_services.py
@@ -116,6 +116,7 @@ def reindex_services(filter_regions=None, filter_service_types=None):
                                 # store it.
                                 if req.status_code == 200:
                                     metadata_url = unicode(test_url)
+                                url = unicode(ref['url'])
                             # next record if not one of the previously mentioned
                             else:
                                 continue

--- a/manage.py
+++ b/manage.py
@@ -38,8 +38,10 @@ def empty_failed():
     fqueue.empty()
 
 @manager.command
-def queue_reindex():
-    queue.enqueue(reindex_services)
+def queue_reindex(filter_regions=None):
+    if filter_regions:
+        filter_regions = filter_regions.split(',')
+    queue.enqueue(reindex_services, filter_regions)
 
 @manager.command
 def queue_daily_status():


### PR DESCRIPTION
Fixes https://github.com/ioos/catalog/issues/423

Because the 'url' variable wasn't set when a proper ERDDAP match was
discovered, the URL actually bled over into the very next CSW record. So
you wound up with SOS endpoints being registered as DAP or WMS pointing
to the ERDDAP instance instead.